### PR TITLE
Namespace of Image for ImageStreamTrigger is now Configurable

### DIFF
--- a/src/main/java/org/springframework/cloud/deployer/spi/openshift/OpenShiftDeployerProperties.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/openshift/OpenShiftDeployerProperties.java
@@ -61,6 +61,10 @@ public class OpenShiftDeployerProperties extends KubernetesDeployerProperties {
 		this.defaultImageTag = defaultImageTag;
 	}
 
+	public String getDefaultImageNamespace(){
+		return getNamespace();
+	}
+
 	public long getUndeployDelay() {
 		return undeployDelay;
 	}

--- a/src/main/java/org/springframework/cloud/deployer/spi/openshift/OpenShiftDeploymentPropertyKeys.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/openshift/OpenShiftDeploymentPropertyKeys.java
@@ -22,6 +22,13 @@ public interface OpenShiftDeploymentPropertyKeys {
 	String OPENSHIFT_DEPLOYMENT_IMAGE_TAG = "spring.cloud.deployer.openshift.image.tag";
 
 	/**
+	 *  The namespace in which the Docker image is placed which used when creating a
+	 *  {@link io.fabric8.openshift.api.model.DeploymentConfig} with a
+	 *  {@link io.fabric8.openshift.api.model.ImageChangeTrigger} trigger.
+	 */
+	String OPENSHIFT_DEPLOYMENT_IMAGE_NAMESPACE = "spring.cloud.deployer.openshift.image.namespace";
+
+	/**
 	 * An inline Dockerfile that will be used as the build input. This Dockerfile will override all
 	 * other Dockerfile usage strategies. See
 	 * https://docs.openshift.org/latest/dev_guide/builds.html#dockerfile-source

--- a/src/main/java/org/springframework/cloud/deployer/spi/openshift/OpenShiftSupport.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/openshift/OpenShiftSupport.java
@@ -33,6 +33,11 @@ public interface OpenShiftSupport extends DataflowSupport {
 				OpenShiftDeploymentPropertyKeys.OPENSHIFT_DEPLOYMENT_IMAGE_TAG, properties.getDefaultImageTag()));
 	}
 
+	default String getImageNamespace(AppDeploymentRequest request, OpenShiftDeployerProperties properties) {
+		return format("%s",request.getDeploymentProperties().getOrDefault(
+				OpenShiftDeploymentPropertyKeys.OPENSHIFT_DEPLOYMENT_IMAGE_NAMESPACE, properties.getDefaultImageNamespace()));
+	}
+
 	default String getEnvironmentVariable(String[] properties, String name) {
 		return getEnvironmentVariable(properties, name, StringUtils.EMPTY);
 	}

--- a/src/main/java/org/springframework/cloud/deployer/spi/openshift/resources/deploymentConfig/DeploymentConfigWithImageChangeTriggerWithIndexSuppportFactory.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/openshift/resources/deploymentConfig/DeploymentConfigWithImageChangeTriggerWithIndexSuppportFactory.java
@@ -45,6 +45,7 @@ public class DeploymentConfigWithImageChangeTriggerWithIndexSuppportFactory
                     .withContainerNames(appId)
                     .withNewFrom()
                         .withKind("ImageStreamTag")
+                        .withNamespace(getImageNamespace(request,openShiftDeployerProperties))
                         .withName(getIndexedImageTag(request, openShiftDeployerProperties, appId))
                     .endFrom()
                 .endImageChangeParams()


### PR DESCRIPTION
Hello Donovan,

In our Case the Image of the Deployment is not in the Same Project in Openshift.
Therefore we must define the Namespace in which the Image can be found.

This is the change, i have added a additional property for the Deployment.

What do you think about this Change?

Regards,
Reto Zeller