### PR TITLE
OpenShift configuration should provide default Maven properties

### DIFF
--- a/src/main/java/org/springframework/cloud/deployer/spi/openshift/OpenShiftAutoConfiguration.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/openshift/OpenShiftAutoConfiguration.java
@@ -76,6 +76,7 @@ public class OpenShiftAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
+	@ConfigurationProperties(prefix = "maven")
 	public MavenProperties mavenProperties() {
 		return new MavenProperties();
 	}

--- a/src/main/java/org/springframework/cloud/deployer/spi/openshift/OpenShiftAutoConfiguration.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/openshift/OpenShiftAutoConfiguration.java
@@ -2,6 +2,7 @@ package org.springframework.cloud.deployer.spi.openshift;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfigureOrder;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.cloud.config.client.ConfigServicePropertySourceLocator;
 import org.springframework.cloud.deployer.resource.maven.MavenProperties;
 import org.springframework.cloud.deployer.spi.app.AppDeployer;
@@ -71,6 +72,12 @@ public class OpenShiftAutoConfiguration {
 	@Bean
 	public MavenResourceJarExtractor mavenResourceJarExtractor() {
 		return new MavenResourceJarExtractor();
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	public MavenProperties mavenProperties() {
+		return new MavenProperties();
 	}
 
 	@Bean

--- a/src/main/java/org/springframework/cloud/deployer/spi/openshift/OpenShiftAutoConfiguration.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/openshift/OpenShiftAutoConfiguration.java
@@ -3,6 +3,7 @@ package org.springframework.cloud.deployer.spi.openshift;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfigureOrder;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.cloud.config.client.ConfigServicePropertySourceLocator;
 import org.springframework.cloud.deployer.resource.maven.MavenProperties;
 import org.springframework.cloud.deployer.spi.app.AppDeployer;


### PR DESCRIPTION
Hi,

Can we add default empty, but overridable, Maven properties to auto configuration?

I'd like to be able to run OpenShift deployer like...

```
AppDeployer deployer = new SpringApplicationBuilder(MyApp.class).run(args).getBean(AppDeployer.class);
deployer.deploy(new AppDeploymentRequest(new AppDefinition("myapp", new HashMap<>()), new DockerResource("myapp")));
```

...without adding empty Maven properties to my application.

Many thanks!