### PR TITLE
Let's reduce default test logging level to INFO

### DIFF
--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -1,0 +1,13 @@
+<configuration>
+
+	<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+		<encoder>
+			<pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+		</encoder>
+	</appender>
+
+	<root level="INFO">
+		<appender-ref ref="STDOUT" />
+	</root>
+
+</configuration>


### PR DESCRIPTION
It seems that current logger level (i.e. DEBUG) kills Travis CI. I propose to reduce test's logging level to INFO. If we need more detailed tests logging in the future we can make it configurable easily, but I would sat that fixing CI should be our priority here.

Cheers!